### PR TITLE
bpf: rework bpf programs into same models.BpfPrograms for API usage

### DIFF
--- a/bpf/gobpf/bpfprogs/bpfprogs.go
+++ b/bpf/gobpf/bpfprogs/bpfprogs.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Djalal Harouni
+
+//go:build linux
+// +build linux
+
+package bpfprogs
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+var (
+	programs map[string]*BpfHandle
+)
+
+type InitProg func() (BpfProg, error)
+
+type BpfProg interface {
+	SetPinPath(pinPath string)
+	SetArgs(args []string)
+
+	Load() error
+
+	Attach() error
+	Destroy()
+
+	Name() string
+	Description() string
+	GetArgs() []string
+
+	GetOutputBuf() *ringbuf.Reader
+	GetOutputBufPath() string
+}
+
+type BpfHandle struct {
+	Prog BpfProg
+	Init InitProg
+}
+
+func init() {
+	programs = make(map[string]*BpfHandle)
+}
+
+func Register(name string, initProg InitProg) error {
+	if _, ok := programs[name]; ok {
+		return fmt.Errorf("bpf program %q already registered", name)
+	}
+	h := BpfHandle{
+		Init: initProg,
+	}
+	programs[name] = &h
+
+	return nil
+}
+
+// ListInitPrograms list initialized embedded Programs.
+func ListInitPrograms() []string {
+	p := []string{}
+	for k, h := range programs {
+		if h.Prog != nil {
+			p = append(p, k)
+		}
+	}
+	return p
+}
+
+// NewProgram initialize the new bpfProg
+func NewProgram(name string) (BpfProg, error) {
+	h, ok := programs[name]
+	if !ok {
+		return nil, fmt.Errorf("bpf program %q was not registered", name)
+	}
+
+	if h.Prog == nil {
+		prog, err := h.Init()
+		if err != nil {
+			return nil, fmt.Errorf("bpf program %q failed to initialize: %v", name, err)
+		}
+		h.Prog = prog
+	}
+
+	return h.Prog, nil
+}
+
+// GetProgram Returns the BpfProg if initialized otherwise error
+func GetProgram(name string) (BpfProg, error) {
+	h, ok := programs[name]
+	if !ok {
+		return nil, fmt.Errorf("bpf program %q was not registered", name)
+	}
+
+	if h.Prog == nil {
+		return nil, fmt.Errorf("bpf program %q was not initialized", name)
+	}
+
+	return h.Prog, nil
+}
+
+// DestroyPrograms  detach and destroy all initialized embedded bpf programs
+func DestroyPrograms() error {
+	for _, h := range programs {
+		if h.Prog != nil {
+			h.Prog.Destroy()
+		}
+	}
+	return nil
+}

--- a/deploy/configs/bpflock/bpf.d/allow.yaml
+++ b/deploy/configs/bpflock/bpf.d/allow.yaml
@@ -4,6 +4,11 @@ bpfmetadata:
   name: bpflock
 bpfspec:
   programs:
+    - name: execsnoop
+      description: "Trace process exec()"
+      doc: https://github.com/linux-lock/bpflock/blob/main/docs/system-and-application-tracing.md#trace-application-execution
+      args:
+        - --exec-snoop=none
     - name: kimglock
       description: "Restrict both direct and indirect modification to a running kernel image" 
       doc: https://github.com/linux-lock/bpflock/blob/main/docs/memory-protections.md#1-kernel-image-lock-down

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -20,6 +20,24 @@ const (
 	ExecSnoop    = "execsnoop"
 )
 
+var (
+	BpfProgDescriptions = map[string]string{
+		ExecSnoop:    "Trace process exec()",
+		FilelessLock: "Restrict fileless binary execution",
+		KimgLock:     "Restrict both direct and indirect modification to a running kernel image",
+		KmodLock:     "Restrict kernel module operations on modular kernels",
+		BpfRestrict:  "Restrict access to the bpf() system call",
+	}
+)
+
+func IsBpfProgInternal(name string) bool {
+	switch name {
+	case ExecSnoop:
+		return true
+	}
+	return false
+}
+
 // IsBpflockAgent checks whether the current process is bpflock (daemon).
 func IsBpflockAgent() bool {
 	binaryName := os.Args[0]

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -108,6 +108,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc) (*Daemon, error) 
 		})
 	}
 
+	// Always destroy embedded Programs
 	cleaner.cleanupFuncs.Add(func() {
 		bpf.DestroyEmbeddedProgs()
 	})

--- a/pkg/daemon/daemon_main.go
+++ b/pkg/daemon/daemon_main.go
@@ -194,7 +194,7 @@ func initializeFlags() {
 	flags.String(option.FilelessLockProfile, "", "filelesslock bpf security profile to restrict fileless binary execution")
 	option.BindEnv(option.FilelessLockProfile)
 
-	flags.String(option.ExecSnoopTarget, "none", "Run execsnoop to trace process execution")
+	flags.String(option.ExecSnoopTarget, defaults.ExecSnoopNone, "Run execsnoop to trace process execution")
 	option.BindEnv(option.ExecSnoopTarget)
 
 	viper.BindPFlags(flags)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -112,11 +112,12 @@ const (
 	BpfProfilePrivileged = "privileged"
 
 	// BpfProfileBaseline is for privileged applications
-	BpfProfileBasleine = "baseline"
+	BpfProfileBaseline = "baseline"
 
 	// BpfProfileRestricted is deny some privileged operations
 	BpfProfileRestricted = "restricted"
 
+	ExecSnoopNone     = "none"
 	ExecSnoopByFilter = "filter"
 	ExecSnoopAll      = "all"
 )


### PR DESCRIPTION
Switch to the new model of handling bpf programs regardless of the
library that was used, either cilium/ebpf or libbpf. This way we
have same model for both embedded and external bpf programs.
    
This will allow later to serve current state of bpf through the API.